### PR TITLE
Remove Terrascan

### DIFF
--- a/.github/workflows/terraform_checks.yml
+++ b/.github/workflows/terraform_checks.yml
@@ -48,25 +48,6 @@ jobs:
       - name: TFLint validate
         run: tflint
 
-  terrascan:
-    name: Terrascan
-
-    needs: terraform_lint
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Check out the codebase
-        uses: actions/checkout@v5
-
-      - name: Run Terrascan
-        uses: tenable/terrascan-action@main
-        with:
-          iac_type: 'terraform'
-          iac_dir: .
-          config_path: .terrascan.toml
-          non_recursive: true
-          verbose: true
-
   kics:
     name: KICS
 

--- a/.terrascan.toml
+++ b/.terrascan.toml
@@ -1,9 +1,0 @@
-[severity]
-  level = "high"
-[rules]
-    skip-rules = [
-        "AC_AWS_0026",
-        "AC_AWS_0032",
-        "AC_AWS_0207"
-    ]
-


### PR DESCRIPTION
Terrascan seems to be abandon-ware now, and it's causing all my PRs to fail their checks. Removing it for now.